### PR TITLE
Add support for Nix-installed dependencies

### DIFF
--- a/install_dependency.sh
+++ b/install_dependency.sh
@@ -32,7 +32,7 @@ install () {
 
 # Create local symlink
 mklink () {
-    for D in /usr/local/bin /opt/{homebrew,local}/bin /usr/local/Cellar/"${PKG}"/*/bin /opt/homebrew/Cellar/"${PKG}"/*/bin; do
+    for D in /run/current-system/sw/bin /usr/local/bin /opt/{homebrew,local}/bin /usr/local/Cellar/"${PKG}"/*/bin /opt/homebrew/Cellar/"${PKG}"/*/bin; do
 	if [ -x "${D}/${EXE}" ]; then
 	    log "ln -sf ${D}/${EXE} ${alfred_workflow_cache}"
 


### PR DESCRIPTION
This pull request adds support for dependencies installed by Nix. It includes changes to the `mklink` function, allowing for the creation of local symlinks to the Nix-installed dependencies.